### PR TITLE
Test auto 0313150735

### DIFF
--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - "${DB_PORT}:8080"
+    env_file:
+      - devops/global.env
+    environment:
+      APP_ENV: ${APP_ENV}
+      DB_HOST: ${DB_HOST}
+      DB_USER: ${DB_USER}
+      DB_PASS: ${DB_PASS}
+      SECRET_KEY: ${SECRET_KEY}
+      LOG_LEVEL: ${LOG_LEVEL}
+      API_ENDPOINT: ${API_ENDPOINT}
+  db:
+    image: mysql:5.7
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: "root"
+  db: # Duplicate name!
+    image: postgres:latest
+    ports:
+      - "5432:5432"

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -19,8 +19,8 @@ services:
     ports:
       - "3306:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: "root"
-  db: # Duplicate name!
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+  postgres_db:
     image: postgres:latest
     ports:
       - "5432:5432"

--- a/devops/main.tf
+++ b/devops/main.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  access_key = "hardcoded-access"
+  secret_key = "hardcoded-secret"
+  region     = "us-east-1"
+}
+
+resource "aws_instance" "task_manager" {
+  ami           = "ami-08c40ec9ead489470"
+  instance_type = "t2.micro"
+  vpc_security_group_ids = ["sg-1234567890"]
+  tags = {
+    Name = "TaskManagerServer"
+  }
+}

--- a/devops/playbook.yml
+++ b/devops/playbook.yml
@@ -1,0 +1,13 @@
+- hosts: all
+  tasks:
+    - name: Install Python
+      apt:
+         name: python3
+      state: present
+    - name: Copy files
+      copy:
+        src: /broken/path/to/files/
+        dest: /home/ubuntu/app/
+    - name: Use undefined variable
+      debug:
+        msg: "{{ foo_variable }}"


### PR DESCRIPTION
This PR introduces a foundational set of DevOps configuration files to establish infrastructure as code and deployment mechanisms.
devops_files/deployment.yaml: Adds a Kubernetes Deployment for the task-manager application, configured with 2 replicas and exposing container port 8080.
devops_files/docker-compose.yml: Includes a Docker Compose setup defining a web service (Nginx) with environment variables, and a db service (PostgreSQL, noting an earlier conflicting MySQL definition).
devops_files/main.tf: Provides a Terraform configuration to provision an AWS EC2 instance (task_manager) in us-east-1, using hardcoded AWS credentials.
devops_files/playbook.yml: Adds an Ansible playbook for server setup, including Python installation, file copying (from a potentially broken path), and an attempt to use an undefined variable.
These files collectively lay the groundwork for automating application deployment and infrastructure management, though some configurations may require further refinement.